### PR TITLE
通过 CI 自动构建并发布 PDF

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: build
+
+on:
+  push:
+    tags:
+      - "v*"
+
+  # Allows you to run this workflow manually from the Actions tab
+  # workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        name: Tectonic Cache
+        with:
+          path: ~/.cache/Tectonic
+          key: ${{ runner.os }}-tectonic-${{ hashFiles('**/*.tex') }}
+          restore-keys: |
+           ${{ runner.os }}-tectonic-
+  
+      - uses: wtfjoke/setup-tectonic@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          biber-version: "latest"
+
+      - name: Run Tectonic + Biber
+        run: tectonic book/book.tex
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: book/book.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: build
+name: release
 
 on:
   push:
@@ -24,10 +24,12 @@ jobs:
           restore-keys: |
            ${{ runner.os }}-tectonic-
   
-      - uses: wtfjoke/setup-tectonic@v1
+      - name: Init Tectonic
+        uses: wtfjoke/setup-tectonic@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          biber-version: "latest"
+          tectonic-version: 0.9.0
+          biber-version: 2.16
 
       - name: Run Tectonic + Biber
         run: tectonic book/book.tex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,19 @@ jobs:
           tectonic-version: 0.9.0
           biber-version: 2.16
 
+      - name: Get Version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
       - name: Run Tectonic + Biber
         run: tectonic book/book.tex
+      
+      - name: Name the Book
+        run: |
+          mv book/book.pdf book/ShangshouCMake-${{ steps.get_version.outputs.VERSION }}.pdf
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: book/book.pdf
+          files: book/ShangshouCMake-*.pdf


### PR DESCRIPTION
尝试增加了一个 `release.yml` 的 CI Workflow，在每次 push 形如 v* 的标签时自动构建 PDF，并将 PDF 发布到 GitHub Release。效果可参看[我的 fork](https://github.com/Yixuan-Wang/Shangshou-CMake/releases)。
